### PR TITLE
Trigger onchange when setting a field in google_partner_address

### DIFF
--- a/google_partner_address/static/src/js/google_partner_address.js
+++ b/google_partner_address/static/src/js/google_partner_address.js
@@ -392,7 +392,7 @@ var AddressWidget = AbstractField.extend({
      */
     _setInputValue(fieldName, value){
         var field = this._getFieldByName(fieldName);
-        field.$input.val(value).trigger("input");
+        field.$input.val(value).trigger("input").trigger("change");
     },
     /**
      * Get the value of a field from the form view.


### PR DESCRIPTION
This caused unpredictable behaviors in onchange methods after a field was filled by the autocomplete widget.

https://pgi.numigi.org/web#id=1482&view_type=form&model=project.task&menu_id=