### PR TITLE
remove_condition_on display (TA#18507)

### DIFF
--- a/partner_contact_type_visible/views/res_partner.xml
+++ b/partner_contact_type_visible/views/res_partner.xml
@@ -11,7 +11,7 @@
             </field>
             <field name="type" position="attributes">
                 <attribute name="attrs">{
-                    'invisible': ['|', ('is_company', '=', True), ('parent_id', '=', False)],
+                    'invisible': ['|', ('is_company', '=', True),
                     'required': ['&amp;', ('is_company', '=', False), ('parent_id', '!=', False)],
                 }</attribute>
             </field>


### PR DESCRIPTION
Field Type must be available when contact is not company and has no parent_id.